### PR TITLE
Add visualizations for processed monthly GAUSS data and regression coefficients (Closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Download the GAUSS data from Globus (requires around 140GB of disk space):
     python scripts/process_monthly_gauss.py  --var tas --data_dir data/gauss --output_dir data/processed
     ```
 
+    Although not necessary, to visualize the processed monthly data for a specific variable in different years, run:
+    ```bash
+    python scripts/visualize_monthly_gauss.py --var tas --year 2042 --data_dir data/processed
+    ```
+
 ### D. Fit the Regression Models
 We fit linear regression models to (1) estimate a gridded map of each variable given a global temperature output by [FaIR](https://github.com/OMS-NetZero/FAIR) and (2) estimate a gridded delta of each variable given a global temperature delta. The models are trained using the GAUSS simulation data.
 
@@ -78,6 +83,11 @@ Or you can fit the regression models for a specific variable using:
 python scripts/fit_map.py --var tas --data_dir data/processed --output_dir data/models
 python scripts/fit_delta.py --var tas --data_dir data/processed --output_dir data/models
 ```
+
+Although not necessary, to visualize the range, IQR, and mean of the linear regression models that estimate a gridded map of each variable given a global temperature output by [FaIR](https://github.com/OMS-NetZero/FAIR) for a variable, run:
+```bash
+python scripts/visualize_map_fit.py --var tas --model CESM2-WACCM --model_dir data/models --data_dir data/processed
+```   
 
 ### E. Cache the Data
 The simulator caches all the data to be loaded more efficiently by the frontend. You can cache the data by running the following command:

--- a/scripts/visualize_map_fit.py
+++ b/scripts/visualize_map_fit.py
@@ -1,0 +1,98 @@
+### visualize_map_fit.py ###
+import fire
+import joblib
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from pathlib import Path
+
+
+def visualize_variability(var, model, model_dir, data_dir):
+    """
+    Visualize the variabiiltiy of the emulation runs.
+    """
+
+    valid_vars = ["tas", "pr"]
+    if var not in valid_vars:
+        raise ValueError(f"var must be one of {valid_vars}")
+    
+    # Load Gauss data for lat, lon
+    data_dir = Path(data_dir)
+    try:
+        ds = xr.open_dataarray(data_dir/var/"output_gauss-baseline.nc")
+    except: 
+        raise FileNotFoundError(f"Check that {data_dir} is a valid dir and contains data in dir {var}.")
+
+    model_dir = Path(model_dir)
+    NUM_EMULATORS=100
+    coef_list = []
+    intercept_list = []
+
+    for i in range(NUM_EMULATORS):
+        filepath = model_dir / var / f"fair_to_smip_{model}_{i}.joblib"
+        if not filepath.exists():
+            raise FileNotFoundError(f"File {filepath} does not exist. Check that model={model} and {model_dir} is correct.")
+
+        m = joblib.load(filepath)
+        
+        # Reshape the coefficients and intercepts
+        coef_reshaped = m.coef_.reshape(ds.lat.size, ds.lon.size)
+        intercept_reshaped = m.intercept_.reshape(ds.lat.size, ds.lon.size)
+
+        # Stack the reshaped coefficients and intercepts along a new axis for emulator runs
+        coef_list.append(coef_reshaped[np.newaxis, :, :])  # Add an extra dimension for 'emulator_run'
+        intercept_list.append(intercept_reshaped[np.newaxis, :, :]) 
+
+    print('Creating visualization!')
+    # Concatenate along the 'emulator_run' dimension
+    coef_dataset = xr.concat([xr.DataArray(coef, dims=['emulator_run', 'lat', 'lon'], 
+                                        coords={'emulator_run': [i], 'lat': ds.lat.values, 'lon': ds.lon.values}) 
+                            for i, coef in enumerate(coef_list)], dim='emulator_run')
+
+    intercept_dataset = xr.concat([xr.DataArray(intercept, dims=['emulator_run', 'lat', 'lon'], 
+                                            coords={'emulator_run': [i], 'lat': ds.lat.values, 'lon': ds.lon.values}) 
+                                for i, intercept in enumerate(intercept_list)], dim='emulator_run')
+
+    # Create a final Dataset containing both the coefficients and intercepts
+    model_runs_ds = xr.Dataset({
+        'model_coef': coef_dataset,
+        'model_intercept': intercept_dataset
+    })
+
+    # Compute the range and IQR of the coef and intercept variables at each lat,lon
+    coef_range = model_runs_ds.model_coef.max(dim='emulator_run') - model_runs_ds.model_coef.min(dim='emulator_run')
+    coef_iqr = model_runs_ds.model_coef.quantile(0.75, dim='emulator_run') - model_runs_ds.model_coef.quantile(0.25, dim='emulator_run')
+    intercept_range = model_runs_ds.model_intercept.max(dim='emulator_run') - model_runs_ds.model_intercept.min(dim='emulator_run')
+    intercept_iqr = model_runs_ds.model_intercept.quantile(0.75, dim='emulator_run') - model_runs_ds.model_intercept.quantile(0.25, dim='emulator_run')
+    coef_mean = model_runs_ds.model_coef.mean(dim='emulator_run')
+    intercept_mean = model_runs_ds.model_intercept.mean(dim='emulator_run')
+
+    stats_ds = xr.Dataset({
+        'coef_range': coef_range,
+        'intercept_range': intercept_range,
+        'coef_iqr': coef_iqr,
+        'intercept_iqr': intercept_iqr,
+        'coef_mean': coef_mean,
+        'intercept_mean': intercept_mean
+    })
+
+    fig = plt.figure(figsize=(12,8))
+    for i, (name, data_var) in enumerate(stats_ds.data_vars.items()):
+        ax = fig.add_subplot(3, 2, i+1, projection=ccrs.PlateCarree())
+        data_var.plot(ax=ax, transform=ccrs.PlateCarree())
+
+        # Add map features
+        ax.coastlines()
+        ax.add_feature(cfeature.BORDERS, linestyle=':')
+        ax.add_feature(cfeature.LAND, alpha=0.1)
+        ax.add_feature(cfeature.OCEAN, alpha=0.1)
+    
+    plt.suptitle(f"{var} {model} Linear Regression Visualization")
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    fire.Fire(visualize_variability)

--- a/scripts/visualize_monthly_gauss.py
+++ b/scripts/visualize_monthly_gauss.py
@@ -1,0 +1,55 @@
+import fire
+import xarray as xr
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from pathlib import Path
+
+
+def visualize_gauss(var, year, data_dir):
+
+    valid_vars = ["tas", "pr"]
+    if var not in valid_vars:
+        raise ValueError(f"var must be one of {valid_vars}")
+    
+    # Error if year is not between 2035 and 2071
+    if not 2035 <= year <= 2070:
+        raise ValueError(f"year must be between 2035 and 2070")
+    
+    scenarios = ["baseline", "1.5", "1.0", "0.5"]
+    data = {}
+    for scenario in scenarios:
+        file_path = Path(data_dir) / var / f"output_gauss-{scenario}.nc"
+        if file_path.exists():
+            ds = xr.open_dataset(file_path)
+            data[scenario] = ds
+        else:
+            print(f"file {file_path} does not exist")
+    
+    # Plot the four cases
+    fig = plt.figure(figsize=(12, 8))
+
+    # Create individual subplots with projection
+    axes = []
+    for i in range(4):
+        ax = fig.add_subplot(2, 2, i+1, projection=ccrs.PlateCarree())
+        axes.append(ax)
+    
+    for ax, (scenario, ds) in zip(axes, data.items()):
+        selected_data = ds[var].sel(time=year, ssp='ssp245', model='CESM2-WACCM')
+        selected_data.plot(ax=ax, transform=ccrs.PlateCarree())
+
+        # Add map features
+        ax.coastlines()
+        ax.add_feature(cfeature.BORDERS, linestyle=':')
+        ax.add_feature(cfeature.LAND, alpha=0.1)
+        ax.add_feature(cfeature.OCEAN, alpha=0.1)
+
+        ax.set_title(f"{scenario}")
+
+    fig.suptitle(f"{var} year={year} ssp245 CESM2-WACCM")
+    plt.tight_layout()
+    plt.show()
+
+if __name__ == "__main__":
+    fire.Fire(visualize_gauss)


### PR DESCRIPTION
**Description:**
This PR addresses the issue raised in #6 where there were no built-in visualization tools for the data processing steps. This change adds two Python files for plotting the monthly GAUSS data for a given variable and year and for plotting the range, IQR, and mean of the linear regression model runs that estimate a gridded map of each variable given a global temperature output by FaIR. At this time, both functions only work with the variables --tas and --pr. 

**Changes Made:**

- Added the file scripts/monthly_gauss.py to visualize the four netCDF files produced by processing the monthly GAUSS data
- Added the file scripts/visualize_map_fit.py to visualize the range, IQR, and mean of the regression coefficients from the 100 emulator runs in the function fit_map.py
- Edited README.md to reflect these visualization features

**Related Issue:**
Closes #6 